### PR TITLE
Fix package repo url in the straight.el section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ in `packages.el`
 
 ``` commonlisp
 (straight-use-package
- '(nushell-mode :type git :host github :repo "azzamsa/nushell-mode"))
+ '(nushell-mode :type git :host github :repo "azzamsa/emacs-nushell"))
 ```
 
 ## Credits


### PR DESCRIPTION
Seems like 5ffe4382fef4bad87ebc1fd5fb9787d40d6ea128 didn't touch the URL in the straight.el section